### PR TITLE
enable using git info for lastmod date

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -21,7 +21,7 @@ copyright = ""
 ############################
 
 # Get last modified date for content from Git?
-enableGitInfo = false
+enableGitInfo = true
 
 # Default language to use (if you setup multilingual support)
 defaultContentLanguage = "en"


### PR DESCRIPTION
Let's see if this fixes RSS feed (index.xml) to use the lastmod date automatically.